### PR TITLE
Apply CRL patches

### DIFF
--- a/cookbook/recipes
+++ b/cookbook/recipes
@@ -4,4 +4,4 @@ if [ ! -d gen-py ]; then
     thrift -r --gen py ../server.thrift &> /dev/null
 fi
 
-python2 recipes.py $1
+python2 recipes.py "$@"

--- a/cookbook/recipes.py
+++ b/cookbook/recipes.py
@@ -17,7 +17,7 @@ def usage():
           " --full\n"
           " --io-error\n"
           " --quota\n"
-          " --delay\n"
+          " --delay DELAY_MICROS\n"
           " --random\n"
           " --specific-syscalls\n"
           " --probability\n"
@@ -57,7 +57,7 @@ def main():
         client.set_all_fault(False, [errno.EDQUOT], 0, "", False, 0, False)
     elif sys.argv[1] == "--delay":
         print("Simulating delayed IO")
-        client.set_all_fault(False, [], 0, "", False, 50000, False)
+        client.set_all_fault(False, [], 0, "", False, int(sys.argv[2]), False)
     elif sys.argv[1] == "--random":
         # Use all errnos, minus any specified in trailing arguments.
         errnos_selected = {code: name for code, name in

--- a/cookbook/recipes.py
+++ b/cookbook/recipes.py
@@ -36,7 +36,7 @@ def connect():
 
 
 def main():
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2:
         usage()
 
     client = connect()
@@ -48,31 +48,35 @@ def main():
         sys.exit(0)
     elif sys.argv[1] == "--full":
         print("Simulating disk full")
-        client.set_all_fault(False, errno.ENOSPC, 0, "", False, 0, False)
+        client.set_all_fault(False, [errno.ENOSPC], 0, "", False, 0, False)
     elif sys.argv[1] == "--io-error":
         print("Simulating IO error")
-        client.set_all_fault(False, errno.EIO, 0, "", False, 0, False)
+        client.set_all_fault(False, [errno.EIO], 0, "", False, 0, False)
     elif sys.argv[1] == "--quota":
         print("Simulating quota exceeded")
-        client.set_all_fault(False, errno.EDQUOT, 0, "", False, 0, False)
+        client.set_all_fault(False, [errno.EDQUOT], 0, "", False, 0, False)
     elif sys.argv[1] == "--delay":
         print("Simulating delayed IO")
-        client.set_all_fault(False, 0, 0, "", False, 50000, False)
+        client.set_all_fault(False, [], 0, "", False, 50000, False)
     elif sys.argv[1] == "--random":
+        # Use all errnos, minus any specified in trailing arguments.
+        errnos_selected = {code: name for code, name in
+                errno.errorcode.items() if name not in sys.argv[1:]}
         print("Simulating random errno")
-        client.set_all_fault(True, 0, 0, "", False, 0, False)
+        print("Using errnos: " + ", ".join(errnos_selected.values()))
+        client.set_all_fault(True, errnos_selected.keys(), 0, "", False, 0, False)
     elif sys.argv[1] == "--specific-syscalls":
         print("Restricting random IO restricted to specific syscalls")
-        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, 0, 0, "", False, 0, False)
+        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, [], 0, "", False, 0, False)
     elif sys.argv[1] == "--probability":
         print("Restricting random IO restricted to specific syscalls and 1% error probability")
-        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, 0, 1000, "", False, 0, False)
+        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, [], 1000, "", False, 0, False)
     elif sys.argv[1] == "--file-pattern":
         print("Restricting random IO restricted to specific syscalls while cursing *.sendmail.cf")
-        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, 0, 0, ".*sendmail.cf", False, 0, False)
+        client.set_fault(['read', 'read_buf', 'write', 'write_buf'], True, [], 0, ".*sendmail.cf", False, 0, False)
     elif sys.argv[1] == "--broken-drive":
         print("The agonising drive simulator")
-        client.set_all_fault(False, errno.EIO, 100, "", False, 100000, False)
+        client.set_all_fault(False, [errno.EIO], 100, "", False, 100000, False)
     else:
         usage()
 

--- a/python_client.py
+++ b/python_client.py
@@ -19,8 +19,8 @@ try:
 
     print(client.get_methods())
 
-    # client.set_fault(['flush', 'fsync', 'fsyncdir'], False, 0, 100000, "", True, 500000)
-    client.set_fault(['flush', 'fsync', 'fsyncdir'], False, 0, 99000, "", True, 500000)
+    # client.set_fault(['flush', 'fsync', 'fsyncdir'], False, [], 100000, "", True, 500000)
+    client.set_fault(['flush', 'fsync', 'fsyncdir'], False, [], 99000, "", True, 500000)
     # client.clear_all_faults()
 
 except Thrift.TException as tx:

--- a/server.thrift
+++ b/server.thrift
@@ -7,7 +7,7 @@
 service server {
 
     // Used to get the list of availables systems calls
-    list<string> get_methods(), 
+    list<string> get_methods(),
 
     // Used to clear all faults sources
     void clear_all_faults(),
@@ -18,7 +18,7 @@ service server {
     // Set fault on a specific list of methods
     void set_fault(list<string> methods,    // the list of methods to operate on
                    bool random,             // Must we return random errno
-                   i32 err_no,              // A specific errno to return
+                   list<i32> err_nos,       // A list of specific errnos to select from
                    i32 probability,         // Fault probability over 100 000
                    string regexp,           // A regexp matching a victim file
                    bool kill_caller,        // Kill -9 the caller process
@@ -27,7 +27,7 @@ service server {
 
     // Works like set_fault but applies the fault to all methods
     void set_all_fault(bool random,
-                       i32 err_no,
+                       list<i32> err_nos,
                        i32 probability,
                        string regexp,
                        bool kill_caller,


### PR DESCRIPTION
**Allow specifying a set of errnos to select from.**

_Taken from scylladb/charybdefs#24._

Allow setting a set of errnos rather than just a particular errno or a
random one from the entire set. Update the cookbook for random faults to
exclude any errnos passed via extra arguments.

My objective here is to be able to exclude a specific errno from
random injection. The Go runtime gets confused by EAGAINs, which cause
it to epoll_wait on the file descriptor. I'd like to exclude EAGAIN from
the set of injected errors for my use case.

---

**cookbook: allow for setting --delay duration**

The CockroachDB test suite currently makes use of charybdefs-nemesis to
induce artificial delays into the filesystem to simulate disk stalls.
Currently, the delay duration is fixed at 50ms. This precludes testing
of faults that last indefinitely.

Change the format of the `--delay` command to take a duration, in
microseconds, allowing for faults of a longer duration.